### PR TITLE
Catch keyboard interrupt + misc minor improvements

### DIFF
--- a/psrecord/main.py
+++ b/psrecord/main.py
@@ -4,8 +4,8 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
 #
-# 1. Redistributions of source code must retain the above copyright notice, this
-# list of conditions and the following disclaimer.
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
 #
 # 2. Redistributions in binary form must reproduce the above copyright notice,
 # this list of conditions and the following disclaimer in the documentation
@@ -13,18 +13,19 @@
 #
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 
-from __future__ import unicode_literals, division, print_function, absolute_import
+from __future__ import (unicode_literals, division, print_function,
+                        absolute_import)
 
-import sys
 import psutil
 import time
 import argparse
@@ -40,9 +41,11 @@ def all_children(pr):
 
 def main():
 
-    parser = argparse.ArgumentParser(description='Record CPU and memory usage for a process')
+    parser = argparse.ArgumentParser(
+        description='Record CPU and memory usage for a process')
 
-    parser.add_argument('process_id_or_command', type=str, help='the process id or command')
+    parser.add_argument('process_id_or_command', type=str,
+                        help='the process id or command')
 
     parser.add_argument('--log', type=str,
                         help='output the statistics to a file')
@@ -67,7 +70,6 @@ def main():
 
     args = parser.parse_args()
 
-
     # Attach to process
     try:
         pid = int(args.process_id_or_command)
@@ -76,7 +78,8 @@ def main():
     except:
         import subprocess
         command = args.process_id_or_command
-        print("Starting up command '{0}' and attaching to process".format(command))
+        print("Starting up command '{0}' and attaching to process"
+              .format(command))
         sprocess = subprocess.Popen(command, shell=True)
         pid = sprocess.pid
 
@@ -87,7 +90,8 @@ def main():
         sprocess.kill()
 
 
-def monitor(pid, logfile=None, plot=None, duration=None, interval=None, include_children=False):
+def monitor(pid, logfile=None, plot=None, duration=None, interval=None,
+            include_children=False):
 
     pr = psutil.Process(pid)
 
@@ -96,10 +100,12 @@ def monitor(pid, logfile=None, plot=None, duration=None, interval=None, include_
 
     if logfile:
         f = open(logfile, 'w')
-        f.write("# {0:12s} {1:12s} {2:12s} {3:12s}\n".format('Elapsed time'.center(12),
-                                                             'CPU (%)'.center(12),
-                                                             'Real (MB)'.center(12),
-                                                             'Virtual (MB)'.center(12)))
+        f.write("# {0:12s} {1:12s} {2:12s} {3:12s}\n".format(
+            'Elapsed time'.center(12),
+            'CPU (%)'.center(12),
+            'Real (MB)'.center(12),
+            'Virtual (MB)'.center(12))
+        )
 
     log = {}
     log['times'] = []
@@ -169,9 +175,9 @@ def monitor(pid, logfile=None, plot=None, duration=None, interval=None, include_
         import matplotlib.pyplot as plt
 
         fig = plt.figure()
-        ax = fig.add_subplot(1,1,1)
+        ax = fig.add_subplot(1, 1, 1)
 
-        ax.plot(log['times'],log['cpu'], '-', lw=1, color='r')
+        ax.plot(log['times'], log['cpu'], '-', lw=1, color='r')
 
         ax.set_ylabel('CPU (%)', color='r')
         ax.set_xlabel('time (s)')
@@ -179,7 +185,7 @@ def monitor(pid, logfile=None, plot=None, duration=None, interval=None, include_
 
         ax2 = ax.twinx()
 
-        ax2.plot(log['times'],log['mem_real'], '-', lw=1, color='b')
+        ax2.plot(log['times'], log['mem_real'], '-', lw=1, color='b')
         ax2.set_ylim(0., max(log['mem_real']) * 1.2)
 
         ax2.set_ylabel('Real Memory (MB)', color='b')


### PR DESCRIPTION
Hi Thomas,

This PR contains some improvements and a bugfix for psutil 2.0 which changed its API:
- Catch keyboard interrupt to clean up things: close the log file, draw the plot, kill the process if needed.
- Process status is now a method (changed with psutil 2.0). + Print elapsed time.
- Allow to use a float interval.
- Pep8
