### PR TITLE
Implement suited unique set size (USS) for memory activity.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,18 @@ To include sub-processes in the CPU and memory stats, use:
 
     psrecord 1330 --log activity.txt --include-children
 
+Memory on linux 
+------------
+
+To record memory activity on linux system as "real memory" 
+better suited unique set size (USS). Uss is ths portion of
+main memory (RAM) occupied by a process which is guaranteed to
+be private to that process:
+
+::
+
+    psrecord 1330 --log activity.txt --linux
+
 Reporting issues
 ================
 

--- a/psrecord/tests/test_main.py
+++ b/psrecord/tests/test_main.py
@@ -11,6 +11,11 @@ p = subprocess.Popen('sleep 5'.split())
 p.wait()
 """
 
+def test_is_uss_possible():
+    if ((sys.platform.startswith("linux")) and psutil.version_info >= (2, 6)):
+        assert is_uss_possible == True
+    else:
+        assert is_uss_possible == False
 
 def test_all_children(tmpdir):
 
@@ -59,6 +64,13 @@ class TestMonitor(object):
         monitor(self.p.pid, plot=filename, duration=3)
         assert os.path.exists(filename)
 
+    def test_linux(self, tmpdir):
+        filename = tmpdir.join('test_logfile').strpath
+        monitor(self.p.pid, logfile=filename, duration=3)
+        assert os.path.exists(filename)
+        is_uss_active = (open(filename, 'r').readlines()[0].find("USS") > 0)
+        assert is_uss_possible() == is_uss_active
+    
     def test_main(self):
         sys.argv = ['psrecord', '--duration=3', "'sleep 10'"]
         main()


### PR DESCRIPTION
Under Linux operating system concepts of resident set size or virtual memory size weren't helping developers who tried to know how much memory their programs were using by this reason more suitable is using unique set size (USS) for memory activity measurement. I added flag --linux which allow to log and plot memory activity as USS.