### PR TITLE
Fix crash on machines without a display

### DIFF
--- a/psrecord/main.py
+++ b/psrecord/main.py
@@ -209,6 +209,9 @@ def monitor(pid, logfile=None, plot=None, duration=None, interval=None,
 
     if plot:
 
+        # Use non-interactive backend, to enable operation on headless machines.
+        import matplotlib as mpl
+        mpl.use('Agg')
         import matplotlib.pyplot as plt
 
         fig = plt.figure()


### PR DESCRIPTION
The bug is, when I try and plot with psrecord on a headless machine (with no displays), then I get the following stack trace:

```
Traceback (most recent call last):
  File "/usr/local/bin/psrecord", line 7, in <module>
    sys.exit(psrecord.main())
  File "/usr/local/lib/python2.7/dist-packages/psrecord/main.py", line 108, in main
    interval=args.interval, include_children=args.include_children)
  File "/usr/local/lib/python2.7/dist-packages/psrecord/main.py", line 214, in monitor
    fig = plt.figure()
  File "/usr/lib/python2.7/dist-packages/matplotlib/pyplot.py", line 539, in figure
    **kwargs)
  File "/usr/lib/python2.7/dist-packages/matplotlib/backend_bases.py", line 171, in new_figure_manager
    return cls.new_figure_manager_given_figure(num, fig)
  File "/usr/lib/python2.7/dist-packages/matplotlib/backends/backend_tkagg.py", line 1049, in new_figure_manager_given_figure
    window = Tk.Tk(className="matplotlib")
  File "/usr/lib/python2.7/lib-tk/Tkinter.py", line 1822, in __init__
    self.tk = _tkinter.create(screenName, baseName, className, interactive, wantobjects, useTk, sync, use)
_tkinter.TclError: no display name and no $DISPLAY environment variable
```

This can be fixed by using non-interactive MPL backend, as far as I can tell there's no need for psrecord to use the interactive one since it's just generating images. Since it's creating pngs only at the moment, using a raster backend is fine.

If there's a reason you'd rather not use 'Agg' by default, then perhaps I can instead add at least a try-catch that prints an instructive message about setting the matplotlib backend via [environment variable](https://matplotlib.org/faq/usage_faq.html#what-is-a-backend).