### PR TITLE
setup.py: Add matplotlib

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,17 +16,17 @@ jobs:
       envs: |
         - linux: py39-test-psutil56
         - linux: py310-test-psutil57
-        - linux: py311-test-psutil58
+        - linux: py311-test-psutil58-alldeps
         - linux: py312-test-psutil59
 
         - macos: py39-test-psutil56
         - macos: py310-test-psutil57
-        - macos: py311-test-psutil58
+        - macos: py311-test-psutil58-alldeps
         - macos: py312-test-psutil59
 
         - windows: py39-test-psutil56
         - windows: py310-test-psutil57
-        - windows: py311-test-psutil58
+        - windows: py311-test-psutil58-alldeps
         - windows: py312-test-psutil59
 
   publish:

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,10 @@ To install, simply do::
 
     pip install psrecord
 
+To install with the optional plotting dependencies, do::
+
+    pip install psrecord[plot]
+
 Usage
 =====
 

--- a/psrecord/main.py
+++ b/psrecord/main.py
@@ -206,6 +206,8 @@ def monitor(pid, logfile=None, plot=None, duration=None, interval=None,
     if plot:
 
         # Use non-interactive backend, to enable operation on headless machines
+        # We import matplotlib here so that the module can be imported even if
+        # matplotlib is not present and the plotting option is unset
         import matplotlib.pyplot as plt
         with plt.rc_context({'backend': 'Agg'}):
 

--- a/psrecord/tests/test_main.py
+++ b/psrecord/tests/test_main.py
@@ -2,6 +2,7 @@ import os
 import sys
 import subprocess
 
+import pytest
 import psutil
 from ..main import main, monitor, all_children
 
@@ -55,6 +56,7 @@ class TestMonitor(object):
         assert len(open(filename, 'r').readlines()) > 0
 
     def test_plot(self, tmpdir):
+        pytest.importorskip("matplotlib")
         filename = tmpdir.join('test_plot.png').strpath
         monitor(self.p.pid, plot=filename, duration=3)
         assert os.path.exists(filename)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = [
 test = [
     "pytest>=7.0",
 ]
+plot = [
+    "matplotlib",
+]
 
 [project.license]
 text = "Simplified BSD License"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{39,310,311,312}-test{-psutil56,-psutil57,-psutil58,-psutil59}
+    py{39,310,311,312}-test{,-psutil56,-psutil57,-psutil58,-psutil59}{,-alldeps}
 requires =
     setuptools >= 30.3.0
     pip >= 19.3.1
@@ -18,6 +18,7 @@ deps =
     psutil59: psutil==5.9.*
 extras =
     test
+    alldeps: plot
 commands =
     pip freeze
     pytest --pyargs psrecord {posargs}


### PR DESCRIPTION
It's imported in `psrecord/main.py` but not installed by setuptools.
Is that okay or do you want it to be optional like [this](https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies)?