### PR TITLE
If neither --log nor --plot is passed, log to stdout. Closes #50

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,160 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/psrecord/__main__.py
+++ b/psrecord/__main__.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2013, Thomas P. Robitaille
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from .main import main  # noqa
+
+__version__ = '1.3.dev0'
+main()

--- a/psrecord/main.py
+++ b/psrecord/main.py
@@ -125,8 +125,7 @@ def monitor(pid, logfile=None, plot=None, duration=None, interval=None,
     f = None
     if logfile is None and plot is None:
         f = sys.stdout
-        # set logfile to '<stdout>'
-        logfile = f.name
+        logfile = '<stdout>'
     elif logfile is not None:
         f = open(logfile, 'w')
 

--- a/psrecord/main.py
+++ b/psrecord/main.py
@@ -26,6 +26,7 @@
 from __future__ import (unicode_literals, division, print_function,
                         absolute_import)
 
+import sys
 import time
 import argparse
 
@@ -62,13 +63,15 @@ def main():
         description='Record CPU and memory usage for a process')
 
     parser.add_argument('process_id_or_command', type=str,
-                        help='the process id or command')
+                        help='the process id or command.')
 
     parser.add_argument('--log', type=str,
-                        help='output the statistics to a file')
+                        help='output the statistics to a file. If neither '
+                             '--log nor --plot are specified, print to print '
+                             'to standard output.')
 
     parser.add_argument('--plot', type=str,
-                        help='output the statistics to a plot')
+                        help='output the statistics to a plot.')
 
     parser.add_argument('--duration', type=float,
                         help='how long to record for (in seconds). If not '
@@ -119,8 +122,15 @@ def monitor(pid, logfile=None, plot=None, duration=None, interval=None,
     # Record start time
     start_time = time.time()
 
-    if logfile:
+    f = None
+    if logfile is None and plot is None:
+        f = sys.stdout
+        # set logfile to '<stdout>'
+        logfile = f.name
+    elif logfile is not None:
         f = open(logfile, 'w')
+
+    if logfile:
         f.write("# {0:12s} {1:12s} {2:12s} {3:12s}\n".format(
             'Elapsed time'.center(12),
             'CPU (%)'.center(12),
@@ -200,7 +210,8 @@ def monitor(pid, logfile=None, plot=None, duration=None, interval=None,
     except KeyboardInterrupt:  # pragma: no cover
         pass
 
-    if logfile:
+    # close the logfile, if it's not stdout
+    if logfile and logfile != '<stdout>':
         f.close()
 
     if plot:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ plot = [
     "matplotlib",
 ]
 
+[project.scripts]
+psrecord = "psrecord.main:main"
+
 [project.license]
 text = "Simplified BSD License"
 

--- a/scripts/psrecord
+++ b/scripts/psrecord
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-
-import sys
-import psrecord
-
-if __name__ == '__main__':
-    sys.exit(psrecord.main())


### PR DESCRIPTION
As explained in #50, currently if neither `--log` nor `--plot` is passed, no information is saved.
This PR solves this problem in the following way if neither `--log` nor `--plot` is passed, log to stdout.

The PR also adds a `.gitignore` file for Python and a `__main__.py` file for easier testing.