### PR TITLE
fix second y-axis label getting cut off

### DIFF
--- a/psrecord/main.py
+++ b/psrecord/main.py
@@ -323,4 +323,4 @@ def monitor(
 
             ax.grid()
 
-            fig.savefig(plot)
+            fig.savefig(plot, bbox_inches='tight')


### PR DESCRIPTION
Issue: Second y-axis label was being cut off in output plots.

Fix: Added bbox_inches='tight' kwarg to fig.savefig(...) in main.py