### PR TITLE
Change placement of flush() call

### DIFF
--- a/psrecord/main.py
+++ b/psrecord/main.py
@@ -274,7 +274,6 @@ def monitor(
                     if include_io:
                         f.write(f",{read_count},{write_count},{read_bytes},{write_bytes}")
                 f.write("\n")
-                f.flush()
 
             if interval is not None:
                 time.sleep(interval)
@@ -296,6 +295,7 @@ def monitor(
 
     # close the logfile, if it's not stdout
     if logfile and logfile != "<stdout>":
+        f.flush()
         f.close()
 
     if plot:


### PR DESCRIPTION
Using `flush()` call during log writing is technically correct, but gives performance degradation.

OS usually must perform IO operation when `flush()` called and it takes time. I got up to 30% slowdown during log collection while plotting gives no such effect.

This PR changes placement of `flush()` call and fixes performance issue.